### PR TITLE
Fix typo in access configuration example

### DIFF
--- a/config/dev.exs.sample
+++ b/config/dev.exs.sample
@@ -1,7 +1,7 @@
 use Mix.Config
 
 config :gmail, :oauth2, [
-  client_id: "CLIENT_ID
+  client_id: "CLIENT_ID",
   client_secret: "CLIENT_SECRET",
   access_token: "ACCESS_TOKEN",
   refresh_token: "REFRESH_TOKEN",


### PR DESCRIPTION
There's a typo in the access configuration example. Took me a while to
find since I was opening with an editor without highlight.
