### PR TITLE
Fix default.

### DIFF
--- a/lib/gmail/utils.ex
+++ b/lib/gmail/utils.ex
@@ -61,7 +61,7 @@ defmodule Gmail.Utils do
 
   @spec load_config(atom) :: list
   def load_config(subject) do
-    Application.get_env(:gmail, subject)
+    Application.get_env(:gmail, subject, [])
   end
 
 end

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Gmail.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :httpoison, :poolboy],
+    [extra_applications: [:logger],
       mod: {Gmail, []}]
   end
 

--- a/test/gmail/utils_test.exs
+++ b/test/gmail/utils_test.exs
@@ -12,5 +12,9 @@ defmodule Gmail.UtilsTest do
     assert 101 == Utils.load_config(:thread, :other_pool_size, 101)
   end
 
+  test "load non existent config with a default" do
+    assert 102 == Utils.load_config(:absent, :pool_size, 102)
+  end
+
 end
 


### PR DESCRIPTION
For default to work, `get_env` needs to return an empty list. `Keyword.get` will return error when being passed a `nil`.